### PR TITLE
Made the version checker optional

### DIFF
--- a/MySQLOO/source/GMModule.cpp
+++ b/MySQLOO/source/GMModule.cpp
@@ -7,6 +7,9 @@
 #define MYSQLOO_VERSION "9"
 #define MYSQLOO_MINOR_VERSION "6"
 
+// Variable to hold the reference to the version check ConVar object
+int iVersionCheckConVar = NULL;
+
 GMOD_MODULE_CLOSE() {
 	/* Deletes all the remaining luaobjects when the server changes map
 	 */
@@ -122,14 +125,35 @@ static int fetchFailed(lua_State* state) {
 static int doVersionCheck(lua_State* state) {
 	GarrysMod::Lua::ILuaBase* LUA = state->luabase;
 	LUA->SetState(state);
-	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
-	LUA->GetField(-1, "http");
-	LUA->GetField(-1, "Fetch");
-	LUA->PushString("https://raw.githubusercontent.com/FredyH/MySQLOO/master/minorversion.txt");
-	LUA->PushCFunction(fetchSuccessful);
-	LUA->PushCFunction(fetchFailed);
-	LUA->Call(3, 0);
-	LUA->Pop(2);
+
+	// Check if the reference to the ConVar object is set
+	if (iVersionCheckConVar != NULL) {
+		LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB); // Push the global table
+			// Retrieve the value of the ConVar
+			LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object
+			LUA->GetField(-1, "GetInt"); // Push the name of the function
+			LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object as the first self argument
+			LUA->Call(1, 1); // Call with 1 argument and 1 return
+			int iVersionCheckEnabled = (int)LUA->GetNumber(-1); // Retrieve the returned value
+
+			// Check if the version check convar is set to 1
+			if (iVersionCheckEnabled == 1) {
+				// Execute the HTTP request
+				LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+				LUA->GetField(-1, "http");
+				LUA->GetField(-1, "Fetch");
+				LUA->PushString("https://raw.githubusercontent.com/FredyH/MySQLOO/master/minorversion.txt");
+				LUA->PushCFunction(fetchSuccessful);
+				LUA->PushCFunction(fetchFailed);
+				LUA->Call(3, 0);
+				LUA->Pop(2);
+			}
+
+			// Free the version check ConVar object reference
+			LUA->ReferenceFree(iVersionCheckConVar);
+		LUA->Pop(); // Pop the global table
+	}
+
 	return 0;
 }
 
@@ -174,6 +198,21 @@ GMOD_MODULE_OPEN() {
 
 	LUA->SetField(-2, "mysqloo");
 	LUA->Pop();
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB); // Push the global table
+		// Create the version check ConVar
+		LUA->GetField(-1, "CreateConVar");
+		LUA->PushString("sv_mysqloo_versioncheck"); // Name
+		LUA->PushString("1"); // Default value
+		LUA->PushNumber(128); // FCVAR flags
+		LUA->PushString("Enable or disable the MySQLOO update checker."); // Help text
+		LUA->PushNumber(0); // Min value
+		LUA->PushNumber(1); // Max value
+		LUA->Call(6, 1); // Call with 6 arguments and 1 result
+		iVersionCheckConVar = LUA->ReferenceCreate(); // Store the created ConVar object as a global variable
+	LUA->Pop(); // Pop the global table
+
 	runInTimer(LUA, 5, doVersionCheck);
+
 	return 1;
 }

--- a/MySQLOO/source/GMModule.cpp
+++ b/MySQLOO/source/GMModule.cpp
@@ -8,11 +8,11 @@
 #define MYSQLOO_MINOR_VERSION "6"
 
 // Variable to hold the reference to the version check ConVar object
-int iVersionCheckConVar = NULL;
+int versionCheckConVar = NULL;
 
 GMOD_MODULE_CLOSE() {
 	// Free the version check ConVar object reference
-	LUA->ReferenceFree(iVersionCheckConVar);
+	LUA->ReferenceFree(versionCheckConVar);
 
 	/* Deletes all the remaining luaobjects when the server changes map
 	 */
@@ -130,16 +130,16 @@ static int doVersionCheck(lua_State* state) {
 	LUA->SetState(state);
 
 	// Check if the reference to the ConVar object is set
-	if (iVersionCheckConVar != NULL) {
+	if (versionCheckConVar != NULL) {
 		// Retrieve the value of the ConVar
-		LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object
+		LUA->ReferencePush(versionCheckConVar); // Push the ConVar object
 		LUA->GetField(-1, "GetInt"); // Push the name of the function
-		LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object as the first self argument
+		LUA->ReferencePush(versionCheckConVar); // Push the ConVar object as the first self argument
 		LUA->Call(1, 1); // Call with 1 argument and 1 return
-		int iVersionCheckEnabled = (int)LUA->GetNumber(-1); // Retrieve the returned value
+		int versionCheckEnabled = (int)LUA->GetNumber(-1); // Retrieve the returned value
 
 		// Check if the version check convar is set to 1
-		if (iVersionCheckEnabled == 1) {
+		if (versionCheckEnabled == 1) {
 			// Execute the HTTP request
 			LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
 			LUA->GetField(-1, "http");
@@ -207,7 +207,7 @@ GMOD_MODULE_OPEN() {
 		LUA->PushNumber(0); // Min value
 		LUA->PushNumber(1); // Max value
 		LUA->Call(6, 1); // Call with 6 arguments and 1 result
-		iVersionCheckConVar = LUA->ReferenceCreate(); // Store the created ConVar object as a global variable
+		versionCheckConVar = LUA->ReferenceCreate(); // Store the created ConVar object as a global variable
 	LUA->Pop(); // Pop the global table
 
 	runInTimer(LUA, 5, doVersionCheck);

--- a/MySQLOO/source/GMModule.cpp
+++ b/MySQLOO/source/GMModule.cpp
@@ -131,27 +131,25 @@ static int doVersionCheck(lua_State* state) {
 
 	// Check if the reference to the ConVar object is set
 	if (iVersionCheckConVar != NULL) {
-		LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB); // Push the global table
-			// Retrieve the value of the ConVar
-			LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object
-			LUA->GetField(-1, "GetInt"); // Push the name of the function
-			LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object as the first self argument
-			LUA->Call(1, 1); // Call with 1 argument and 1 return
-			int iVersionCheckEnabled = (int)LUA->GetNumber(-1); // Retrieve the returned value
+		// Retrieve the value of the ConVar
+		LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object
+		LUA->GetField(-1, "GetInt"); // Push the name of the function
+		LUA->ReferencePush(iVersionCheckConVar); // Push the ConVar object as the first self argument
+		LUA->Call(1, 1); // Call with 1 argument and 1 return
+		int iVersionCheckEnabled = (int)LUA->GetNumber(-1); // Retrieve the returned value
 
-			// Check if the version check convar is set to 1
-			if (iVersionCheckEnabled == 1) {
-				// Execute the HTTP request
-				LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
-				LUA->GetField(-1, "http");
-				LUA->GetField(-1, "Fetch");
-				LUA->PushString("https://raw.githubusercontent.com/FredyH/MySQLOO/master/minorversion.txt");
-				LUA->PushCFunction(fetchSuccessful);
-				LUA->PushCFunction(fetchFailed);
-				LUA->Call(3, 0);
-				LUA->Pop(2);
-			}
-		LUA->Pop(); // Pop the global table
+		// Check if the version check convar is set to 1
+		if (iVersionCheckEnabled == 1) {
+			// Execute the HTTP request
+			LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+			LUA->GetField(-1, "http");
+			LUA->GetField(-1, "Fetch");
+			LUA->PushString("https://raw.githubusercontent.com/FredyH/MySQLOO/master/minorversion.txt");
+			LUA->PushCFunction(fetchSuccessful);
+			LUA->PushCFunction(fetchFailed);
+			LUA->Call(3, 0);
+			LUA->Pop(2);
+		}
 	}
 
 	return 0;

--- a/MySQLOO/source/GMModule.cpp
+++ b/MySQLOO/source/GMModule.cpp
@@ -11,6 +11,9 @@
 int iVersionCheckConVar = NULL;
 
 GMOD_MODULE_CLOSE() {
+	// Free the version check ConVar object reference
+	LUA->ReferenceFree(iVersionCheckConVar);
+
 	/* Deletes all the remaining luaobjects when the server changes map
 	 */
 	for (auto query : LuaObjectBase::luaRemovalObjects) {
@@ -148,9 +151,6 @@ static int doVersionCheck(lua_State* state) {
 				LUA->Call(3, 0);
 				LUA->Pop(2);
 			}
-
-			// Free the version check ConVar object reference
-			LUA->ReferenceFree(iVersionCheckConVar);
 		LUA->Pop(); // Pop the global table
 	}
 


### PR DESCRIPTION
Fixes #58.

* Added [a global variable](https://github.com/FredyH/MySQLOO/blob/e4a76730708f470712fa1e7b7c482c10664d644e/MySQLOO/source/GMModule.cpp#L11) at the top of the main file.
* Added [creating convar](https://github.com/FredyH/MySQLOO/blob/e4a76730708f470712fa1e7b7c482c10664d644e/MySQLOO/source/GMModule.cpp#L202-L213) in the module open function.
* Added [convar value checking](https://github.com/FredyH/MySQLOO/blob/e4a76730708f470712fa1e7b7c482c10664d644e/MySQLOO/source/GMModule.cpp#L130-L155) in the doVersionCheck() function.

While I could have put all the code inside the module open function, I feel it's better to still let the timer be created so any convar changes prior to the server dehibernating (timers & think hooks starting) are applied.