### PR TITLE
Fixed libmysqlclient library link on Linux/macOS

### DIFF
--- a/BuildProjects.lua
+++ b/BuildProjects.lua
@@ -71,5 +71,5 @@ solution "MySQLOO"
 		if os.target() == "windows" then
 			links { "libmysql", "ws2_32.lib", "shlwapi.lib" }
 		elseif os.target() == "macosx" or os.target() == "linux" then
-			links { "libmysql", "pthread", "dl" }
+			links { "mysqlclient", "pthread", "dl" }
 		end


### PR DESCRIPTION
`ld` currently looks for `liblibmysql` instead of `libmysqlclient`, preventing a successful compile.

Tested on Ubuntu 18.04 LTS with the `libmysqlclient-dev` package installed, version `8.0.20-1ubuntu18.04`