### PR TITLE
Make version check a pcall

### DIFF
--- a/MySQLOO/source/GMModule.cpp
+++ b/MySQLOO/source/GMModule.cpp
@@ -147,7 +147,7 @@ static int doVersionCheck(lua_State* state) {
 			LUA->PushString("https://raw.githubusercontent.com/FredyH/MySQLOO/master/minorversion.txt");
 			LUA->PushCFunction(fetchSuccessful);
 			LUA->PushCFunction(fetchFailed);
-			LUA->Call(3, 0);
+			LUA->PCall(3, 0, 0);
 			LUA->Pop(2);
 		}
 	}


### PR DESCRIPTION
http.Fetch now throws an error if the http interface hasn't been initialized yet. If MySQL happens to make a request early enough, this will cause the server to segfault. Changing this to a PCall addresses the crash. 